### PR TITLE
Upgrade to sodium-native@3.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ language: node_js
 node_js:
 - node
 - lts/*
+- '13'
+- '12'
 - '10'
-- 8
-- 6
-- 4
 jobs:
   include:
   - stage: npm release

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "nanoassert": "^1.0.0",
-    "sodium-native": "^2.2.1"
+    "sodium-native": "^3.1.1"
   },
   "devDependencies": {
     "tape": "^4.6.3"


### PR DESCRIPTION
It would be nice to get the most recent sodium-native in here to benefit from the N-API migration.

I think node 4 and 6 need to be dropped because they don't support N-API. The rest should be fine. I'll run the tests with the unchanged .travis.yml first and then fix the node versions.

... node 8 also needed to be dropped. The versions are now in sync with the ones in `sodium-native`.